### PR TITLE
ssh/knownhosts: fix line matching, when multiple lines

### DIFF
--- a/ssh/knownhosts/knownhosts.go
+++ b/ssh/knownhosts/knownhosts.go
@@ -135,7 +135,7 @@ func (l *keyDBLine) match(addrs []addr) bool {
 type hostKeyDB struct {
 	// Serialized version of revoked keys
 	revoked map[string]*KnownKey
-	lines   []keyDBLine
+	lines   []*keyDBLine
 }
 
 func (db *hostKeyDB) String() string {
@@ -287,7 +287,7 @@ func (db *hostKeyDB) parseLine(line []byte, filename string, linenum int) error 
 		})
 	}
 
-	db.lines = append(db.lines, entry)
+	db.lines = append(db.lines, &entry)
 	return nil
 }
 


### PR DESCRIPTION
When using knownhosts.New() over a standard file generated by ssh
with multiples hosts, the callback doesn't validate match any host
even when is on the file. This commit fix the issue and adds a
test to validate the solution.

Fixes golang/go#19994

Change-Id: I4aec415f3233ad6e85d9f5f4ab2f3d93b56d93cf